### PR TITLE
Restrict sass-embedded version

### DIFF
--- a/dartsass-ruby.gemspec
+++ b/dartsass-ruby.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.6.0'
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency 'sass-embedded', '~> 1.54'
+  spec.add_runtime_dependency 'sass-embedded', '~> 1.54', '< 1.67'
 
   spec.add_development_dependency 'minitest', '~> 5.16.0'
   spec.add_development_dependency 'minitest-around', '~> 0.5.0'


### PR DESCRIPTION
This is a workaround until compatibility with sass-embedded 1.67+ is implemented.

See https://github.com/tablecheck/dartsass-sprockets/issues/13 for background


